### PR TITLE
ft: add port cli flag, ch: added some comments

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,10 @@
+package main
+
+import "flag"
+
+func handleCLI() *string {
+	portArgument := flag.String("port", "5101", "sets the port used by the web server")
+	flag.Parse()
+
+	return portArgument
+}

--- a/main.go
+++ b/main.go
@@ -10,11 +10,13 @@ import (
 
 func uploadHandler(w http.ResponseWriter, r *http.Request) {
 
+	// Denies request if not a POST Request.
 	if r.Method != "POST" {
 		fmt.Fprintf(w, "This endpoint requires a POST Request. \n")
 		return
 	}
 
+	// Reading File
 	file, handler, err := r.FormFile("files[]")
 	if err != nil {
 		fmt.Fprintf(w, "There was an error: %v.", err)
@@ -23,7 +25,9 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
+	// Calls method to randomly select site
 	site := selectSite()
+
 	body, err := sharex.HandleUpload(file, handler, site)
 	if err != nil {
 		fmt.Fprintf(w, "There was an error: %v", err)
@@ -36,9 +40,13 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// Handle CLI Flags
+	portArgument := handleCLI()
 
+	// Create route for uploading
 	http.HandleFunc("/upload", uploadHandler)
 
-	fmt.Println("Started...")
-	log.Fatal(http.ListenAndServe("127.0.0.1:8080", nil))
+	fmt.Printf("[Tourner] Started successfully on port %v", *portArgument)
+	// Start web server
+	log.Fatal(http.ListenAndServe("127.0.0.1:"+*portArgument, nil))
 }

--- a/sharex/upload.go
+++ b/sharex/upload.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 )
 
+// Upload the file from the local server to the destination origin.
 func HandleUpload(f multipart.File, h *multipart.FileHeader, s string) ([]byte, error) {
 
 	buf := new(bytes.Buffer)
@@ -34,6 +35,7 @@ func HandleUpload(f multipart.File, h *multipart.FileHeader, s string) ([]byte, 
 	req, _ := http.NewRequest("POST", s, buf)
 
 	req.Header.Add("authority", s)
+	// * Will need to change dynamically for ChibiSafe
 	req.Header.Add("accept", "accept: application/vnd.chibisafe.json")
 	req.Header.Add("accept-language", "en-US,en;q=0.8")
 	req.Header.Add("cache-control", "no-cache")


### PR DESCRIPTION
* Uses the Go "flag" package to add a CLI Flag "port" to specify the port, also changes the default port from 8080 to 5101
* Added some basic comments to make code more easily understood, if it wasn't already.